### PR TITLE
Fix quoting the scalar starting with the "%"

### DIFF
--- a/Form/Type/CKFinderFileChooserType.php
+++ b/Form/Type/CKFinderFileChooserType.php
@@ -70,14 +70,6 @@ class CKFinderFileChooserType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return $this->getName();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
         return 'ckfinder_file_chooser';
     }
 }

--- a/Resources/config/form.yml
+++ b/Resources/config/form.yml
@@ -3,6 +3,6 @@ parameters:
 
 services:
     ckfinder.form.file_chooser.type:
-        class: %ckfinder.form.file_chooser.type.class%
+        class: '%ckfinder.form.file_chooser.type.class%'
         tags:
-            - { name: form.type, alias: ckfinder_file_chooser }
+            - { name: form.type }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,11 +1,11 @@
 services:
     ckfinder.connector.auth:
-        class: %ckfinder.connector.auth.class%
+        class: '%ckfinder.connector.auth.class%'
         calls:
             - [setContainer, ['@service_container']]
 
     ckfinder.connector:
-        class: %ckfinder.connector.class%
-        arguments: [%ckfinder.connector.config%]
+        class: '%ckfinder.connector.class%'
+        arguments: ['%ckfinder.connector.config%']
         calls:
             - [offsetSet, ['authentication', '@ckfinder.connector.auth']]

--- a/Tests/Form/Type/CKFinderFileChooserTypeTest.php
+++ b/Tests/Form/Type/CKFinderFileChooserTypeTest.php
@@ -25,7 +25,7 @@ class CKFinderFileChooserTypeTest extends TypeTestCase
         $fieldType = new CKFinderFileChooserType();
 
         return array(new PreloadedExtension(array(
-            $fieldType->getName() => $fieldType,
+            $fieldType,
         ), array()));
     }
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
         "league/flysystem-aws-s3-v2": "1.0.3",
         "league/flysystem-cached-adapter": "~1.0.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~5.7"
+    },
     "autoload": {
         "psr-4": {
             "CKSource\\Bundle\\CKFinderBundle\\": "",


### PR DESCRIPTION
Fix quoting the scalar starting with the "%"
+
Remove redundant CKFinderFileChooserType::getName method
Remove redundant form alias